### PR TITLE
attempt for multiple livewire draws

### DIFF
--- a/src/applauncher.js
+++ b/src/applauncher.js
@@ -11,7 +11,7 @@ function startApp() {
   dwvjq.gui.setup();
 
   // show dwv version
-  dwvjq.gui.appendVersionHtml('0.6.0-beta');
+  dwvjq.gui.appendVersionHtml(dwv.getVersion());
 
   // application options
   var filterList = ['Threshold', 'Sharpen', 'Sobel'];
@@ -120,6 +120,14 @@ function startApp() {
       myapp.abortLoad();
     }
   };
+  window.addEventListener('dblclick', function (event) {    
+    console.log('dblclick received');
+    var controller = myapp.getToolboxController();
+    var selectedTool = controller.getSelectedTool();
+    if (selectedTool instanceof dwv.tool.Livewire) {
+      drawListGui.performupdate();
+    }
+  });
 
   // handle load events
   var nLoadItem = null;

--- a/src/gui/generic.js
+++ b/src/gui/generic.js
@@ -177,7 +177,9 @@ dwvjq.gui.DrawList = function (app) {
     app.addEventListener('drawchange', update);
     app.addEventListener('drawdelete', update);
   };
-
+  this.performupdate = function(){
+    update({editable: this.checked});
+  }
   /**
    * Update the draw list html element
    * @param {Object} event A change event, decides if the table is editable

--- a/src/gui/tools.js
+++ b/src/gui/tools.js
@@ -24,6 +24,15 @@ dwvjq.gui.Toolbox = function (app) {
         toolGuis[gui].display(false);
       }
       toolGuis[event.currentTarget.value].display(true);
+      if(event.currentTarget.value=="Livewire"){
+        console.log('livewire patch');
+        //Special processing here for livewire
+        // var drawDisplayDetails = app.getDrawDisplayDetails();
+        var st_json = app.getState();
+        var st = JSON.parse(st_json);
+        app.deleteDraws();
+        app.setDrawings(st.drawings,st.drawingDetails);
+      }
     };
 
     // tool list element


### PR DESCRIPTION
This workaround allows for multiple livewire draws. But also undo history is messed up.
Uses app.getState, app.deleteDraws, then app.setDrawings

